### PR TITLE
fix(project): give a default project name

### DIFF
--- a/src/main/java/io/openshift/launchpad/ui/input/ProjectName.java
+++ b/src/main/java/io/openshift/launchpad/ui/input/ProjectName.java
@@ -29,7 +29,7 @@ public class ProjectName extends AbstractUIInputDecorator<String>
    private static final Pattern SPECIAL_CHARS = Pattern.compile("[-a-z0-9]|[a-z0-9][-a-z0-9]*[a-z0-9]");
 
    @Inject
-   @WithAttributes(label = "OpenShift Project name", required = true)
+   @WithAttributes(label = "OpenShift Project name", required = true, defaultValue="MyApp")
    @UnwrapValidatedValue
    @Length(min = 1, max = 24)
    private UIInput<String> named;


### PR DESCRIPTION
@gastaldi in the OSiO quickstart flow we set a default value for this field a web UI level. not having a default value for this filed causes the UI to return a canGoToNextStep false.

Could you review?