### PR TITLE
expose the inputs for maven coordinates to derived classes

### DIFF
--- a/src/main/java/io/openshift/launchpad/ui/booster/ProjectInfoStep.java
+++ b/src/main/java/io/openshift/launchpad/ui/booster/ProjectInfoStep.java
@@ -395,6 +395,21 @@ public class ProjectInfoStep implements UIWizardStep
       return gitHubRepositoryName;
    }
 
+   protected UIInput<String> getGroupId()
+   {
+      return groupId;
+   }
+
+   protected UIInput<String> getArtifactId()
+   {
+      return artifactId;
+   }
+
+   protected UIInput<String> getVersion()
+   {
+      return version;
+   }
+
    protected String getGithubRepositoryNameValue()
    {
       String repository = gitHubRepositoryName.getValue();


### PR DESCRIPTION
so that we can default the artifactId to the project name in fabric8/OSIO